### PR TITLE
Add Flask backend with image upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# ai-art-evaluator-platform
+# AI Art Evaluator Platform
+
+This repository contains a simple Flask backend for evaluating uploaded images.
+
+## Running the Backend
+
+1. Install the Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Start the server:
+
+```bash
+python backend/app.py
+```
+
+The `/api/evaluate` endpoint accepts an image file uploaded via `multipart/form-data` under the field name `image`.

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+uploads/*
+!uploads/.gitkeep

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from werkzeug.utils import secure_filename
+import os
+
+app = Flask(__name__)
+CORS(app)
+
+UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+
+ALLOWED_EXTENSIONS = {'jpg', 'jpeg', 'png'}
+
+def allowed_file(filename: str) -> bool:
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@app.route('/api/evaluate', methods=['POST'])
+def evaluate():
+    """Accept an image upload and return the saved filename."""
+    if 'image' not in request.files:
+        return jsonify({'error': 'No image file provided'}), 400
+
+    file = request.files['image']
+    if file.filename == '':
+        return jsonify({'error': 'No image selected'}), 400
+
+    if file and allowed_file(file.filename):
+        filename = secure_filename(file.filename)
+        save_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        file.save(save_path)
+        return jsonify({'filename': filename}), 200
+
+    return jsonify({'error': 'Invalid file type'}), 400
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- build minimal Flask backend
- implement `/api/evaluate` route accepting image uploads
- save uploads in `backend/uploads` and return filename
- ignore uploaded files in git
- update README with usage instructions

## Testing
- `python -m py_compile backend/app.py`
- `pytest -q`