### PR TITLE
Fix CORS to allow React dev requests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,7 +4,12 @@ from werkzeug.utils import secure_filename
 import os
 
 app = Flask(__name__)
-CORS(app)
+# Allow CORS requests from the React development server
+CORS(
+    app,
+    resources={r"/api/*": {"origins": "http://localhost:3000"}},
+)
+app.config["CORS_HEADERS"] = "Content-Type"
 
 UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)


### PR DESCRIPTION
## Summary
- configure Flask-CORS to only allow `http://localhost:3000` for `/api/*`
- document the attempt to run the Flask server for testing

## Testing
- `python3 backend/app.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*