### PR TITLE
Add frontend skeleton and improve CORS handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Node.js
+node_modules/

--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ python backend/app.py
 ```
 
 The `/api/evaluate` endpoint accepts an image file uploaded via `multipart/form-data` under the field name `image`.
+
+## Running the Frontend
+
+1. Install Node dependencies:
+
+```bash
+cd frontend
+npm install
+```
+
+2. Start the React development server:
+
+```bash
+npm start
+```
+
+The React app is configured with a `proxy` to `http://localhost:5000`, allowing API requests to `/api/*` without CORS issues.

--- a/backend/app.py
+++ b/backend/app.py
@@ -7,7 +7,12 @@ app = Flask(__name__)
 # Allow CORS requests from the React development server
 CORS(
     app,
-    resources={r"/api/*": {"origins": "http://localhost:3000"}},
+    resources={
+        r"/api/*": {
+            "origins": ["http://localhost:3000", "http://127.0.0.1:3000"],
+        }
+    },
+    supports_credentials=True,
 )
 app.config["CORS_HEADERS"] = "Content-Type"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "proxy": "http://localhost:5000"
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+
+function App() {
+  const [file, setFile] = useState(null);
+  const handleChange = (e) => {
+    setFile(e.target.files[0]);
+  };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('image', file);
+    try {
+      const res = await fetch('/api/evaluate', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await res.json();
+      console.log(data);
+    } catch (err) {
+      console.error('Upload failed', err);
+    }
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <input type="file" onChange={handleChange} />
+        <button type="submit">Upload</button>
+      </form>
+    </div>
+  );
+}
+
+export default App;


### PR DESCRIPTION
## Summary
- expand CORS configuration to support multiple dev origins
- add React frontend skeleton using a proxy to the backend
- ignore node_modules in git
- document how to run the frontend in README

## Testing
- `python -m py_compile backend/app.py`
- *(fails: `ModuleNotFoundError: No module named 'flask'` when trying to run server)*