### PR TITLE
Fix CORS and fetch URL

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,17 +4,8 @@ from werkzeug.utils import secure_filename
 import os
 
 app = Flask(__name__)
-# Allow CORS requests from the React development server
-CORS(
-    app,
-    resources={
-        r"/api/*": {
-            "origins": ["http://localhost:3000", "http://127.0.0.1:3000"],
-        }
-    },
-    supports_credentials=True,
-)
-app.config["CORS_HEADERS"] = "Content-Type"
+# Enable CORS for development
+CORS(app, resources={r"/api/*": {"origins": ["http://localhost:3000"]}})
 
 UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,7 +11,7 @@ function App() {
     const formData = new FormData();
     formData.append('image', file);
     try {
-      const res = await fetch('/api/evaluate', {
+      const res = await fetch('http://localhost:5000/api/evaluate', {
         method: 'POST',
         body: formData,
       });


### PR DESCRIPTION
## Summary
- allow frontend origin in Flask CORS config
- point React fetch call directly to backend URL

## Testing
- `npm test` *(fails: Missing script)*